### PR TITLE
Check for Flag Arguments

### DIFF
--- a/CleanCode/src/CleanCode/CleanCode.8.2.csproj
+++ b/CleanCode/src/CleanCode/CleanCode.8.2.csproj
@@ -51,6 +51,9 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Features\FlagsMethodArguments\Highlighting.cs" />
+    <Compile Include="Features\FlagsMethodArguments\FlagsMethodArgumentsChange.cs" />
+    <Compile Include="Features\FlagsMethodArguments\FlagsMethodArgumentsCheck.cs" />
     <Compile Include="Features\TooManyChainedReferences\Highlighting.cs" />
     <Compile Include="Features\TooManyChainedReferences\InvalidateOnMaximumChainedCalls.cs" />
     <Compile Include="Features\TooManyChainedReferences\TooManyChainedReferencesCheck.cs" />

--- a/CleanCode/src/CleanCode/CleanCodeDaemonStageProcess.cs
+++ b/CleanCode/src/CleanCode/CleanCodeDaemonStageProcess.cs
@@ -28,6 +28,7 @@
 using System;
 using CleanCode.Features.ClassTooBig;
 using CleanCode.Features.ExcessiveIndentation;
+using CleanCode.Features.FlagsMethodArguments;
 using CleanCode.Features.MethodNameNotMeaningful;
 using CleanCode.Features.MethodTooLong;
 using CleanCode.Features.TooManyChainedReferences;
@@ -45,7 +46,7 @@ namespace CleanCode
     public class CleanCodeDaemonStageProcess : CSharpDaemonStageProcessBase
     {
         private readonly IContextBoundSettingsStore settingsStore;
-
+        private readonly FlagsMethodArgumentsCheck flagsMethodArgumentsCheck; 
         private readonly MethodTooLongCheck methodTooLongCheck;
         private readonly ClassTooBigCheck classTooBigCheck;
         private readonly TooManyMethodArgumentsCheck tooManyArgumentsCheck;
@@ -67,6 +68,7 @@ namespace CleanCode
             tooManyDependenciesCheck = new TooManyDependenciesCheck(settingsStore);
             methodNamesNotMeaningfulCheck = new MethodNamesNotMeaningfulCheck(settingsStore);
             tooManyChainedReferencesCheck = new TooManyChainedReferencesCheck(settingsStore);
+            flagsMethodArgumentsCheck = new FlagsMethodArgumentsCheck(settingsStore);
         }
 
         public override void Execute(Action<DaemonStageResult> commiter)
@@ -80,6 +82,7 @@ namespace CleanCode
             tooManyArgumentsCheck.ExecuteIfEnabled(methodDeclaration, context);
             excessiveIndentationCheck.ExecuteIfEnabled(methodDeclaration, context);
             methodNamesNotMeaningfulCheck.ExecuteIfEnabled(methodDeclaration, context);
+            flagsMethodArgumentsCheck.ExecuteIfEnabled(methodDeclaration, context);
         }
 
         public override void VisitConstructorDeclaration(IConstructorDeclaration constructorDeclaration, IHighlightingConsumer context)

--- a/CleanCode/src/CleanCode/Features/FlagsMethodArguments/FlagsMethodArgumentsChange.cs
+++ b/CleanCode/src/CleanCode/Features/FlagsMethodArguments/FlagsMethodArgumentsChange.cs
@@ -1,0 +1,45 @@
+#region License
+// Copyright (C) 2012 Hadi Hariri and Contributors
+// 
+// Permission is hereby granted, free of charge, to any person 
+// obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software 
+// without restriction, including without limitation the rights 
+// to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons 
+// to whom the Software is furnished to do so, subject to the 
+// following conditions:
+//  
+// The above copyright notice and this permission notice shall 
+// be included in all copies or substantial portions of the Software.
+//  
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT
+// LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+// OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+// OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+// OR OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using CleanCode.Settings;
+using JetBrains.Application.Settings;
+using JetBrains.DataFlow;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Daemon;
+
+namespace CleanCode.Features.FlagsMethodArguments
+{
+    [SolutionComponent]
+    public class FlagsMethodArgumentsChange
+    {
+        public FlagsMethodArgumentsChange(Lifetime lifetime, Daemon daemon, ISettingsStore settingsStore)
+        {
+            var minMethodNameLenght = settingsStore.Schema.GetScalarEntry((CleanCodeSettings s) => s.FlagMethodArgumentsMinimum);
+            settingsStore.AdviseChange(lifetime, minMethodNameLenght, daemon.Invalidate);
+        }
+    }
+}

--- a/CleanCode/src/CleanCode/Features/FlagsMethodArguments/FlagsMethodArgumentsCheck.cs
+++ b/CleanCode/src/CleanCode/Features/FlagsMethodArguments/FlagsMethodArgumentsCheck.cs
@@ -1,0 +1,43 @@
+using CleanCode.Resources;
+using CleanCode.Settings;
+using JetBrains.Application.Settings;
+using JetBrains.ReSharper.Daemon.CSharp.Stages;
+using JetBrains.ReSharper.Daemon.Stages;
+using JetBrains.ReSharper.Psi.CSharp.Tree;
+using JetBrains.ReSharper.Psi.Tree;
+using System.Linq;
+
+namespace CleanCode.Features.FlagsMethodArguments
+{
+    public class FlagsMethodArgumentsCheck : SimpleCheck<IMethodDeclaration, int>
+    {
+        public FlagsMethodArgumentsCheck(IContextBoundSettingsStore settingsStore)
+            : base(settingsStore)
+        {
+        }
+
+        protected override void ExecuteCore(IMethodDeclaration methodDeclaration, IHighlightingConsumer consumer)
+        {
+            var threshold = Threshold;
+
+            var numberOfFlagsArgument = methodDeclaration.ParameterDeclarations.Count(
+                    declaration => declaration.Type.ToString() == typeof(System.Boolean).FullName);
+
+            if (numberOfFlagsArgument > threshold)
+            {
+                var highlighting = new Highlighting(Warnings.FlagMethodArguments);
+                consumer.AddHighlighting(highlighting, methodDeclaration.GetNameDocumentRange());
+            }
+        }
+
+        protected override int Threshold
+        {
+            get { return SettingsStore.GetValue((CleanCodeSettings s) => s.FlagMethodArgumentsMinimum); }
+        }
+
+        protected override bool IsEnabled
+        {
+            get { return SettingsStore.GetValue((CleanCodeSettings s) => s.FlagMethodArgumentsEnabled); }
+        }
+    }
+}

--- a/CleanCode/src/CleanCode/Features/FlagsMethodArguments/Highlighting.cs
+++ b/CleanCode/src/CleanCode/Features/FlagsMethodArguments/Highlighting.cs
@@ -1,0 +1,73 @@
+#region License
+// Copyright (C) 2012 Hadi Hariri and Contributors
+// 
+// Permission is hereby granted, free of charge, to any person 
+// obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software 
+// without restriction, including without limitation the rights 
+// to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons 
+// to whom the Software is furnished to do so, subject to the 
+// following conditions:
+//  
+// The above copyright notice and this permission notice shall 
+// be included in all copies or substantial portions of the Software.
+//  
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT
+// LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+// OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+// OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+// OR OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using CleanCode.Features.FlagsMethodArguments;
+using JetBrains.ReSharper.Daemon;
+using JetBrains.ReSharper.Psi.CSharp;
+
+[assembly: RegisterConfigurableSeverity(Highlighting.SeverityID, null, 
+    HighlightingGroupIds.CodeSmell, "Flags Method Arguments",
+    "This method does more than one thing. Please review it.",
+    Severity.WARNING, false)]
+
+namespace CleanCode.Features.FlagsMethodArguments
+{
+    /// <summary>
+    /// The highlighting that warns about high complexity
+    /// </summary>
+    [ConfigurableSeverityHighlighting(SeverityID, CSharpLanguage.Name)]
+    public class Highlighting : IHighlighting
+    {
+        internal const string SeverityID = "FlagsMethodArguments";
+        private readonly string tooltip;
+
+        public Highlighting(string toolTip)
+        {
+            tooltip = toolTip;
+        }
+
+        public string ToolTip
+        {
+            get { return tooltip; }
+        }
+
+        public string ErrorStripeToolTip
+        {
+            get { return tooltip; }
+        }
+
+        public int NavigationOffsetPatch
+        {
+            get { return 0; }
+        }
+
+        public bool IsValid()
+        {
+            return true;
+        }
+    }
+}

--- a/CleanCode/src/CleanCode/Resources/Warnings.Designer.cs
+++ b/CleanCode/src/CleanCode/Resources/Warnings.Designer.cs
@@ -88,6 +88,15 @@ namespace CleanCode.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This method does more than one thing. Passing a boolean into a function is a truly terrible practice..
+        /// </summary>
+        public static string FlagMethodArguments {
+            get {
+                return ResourceManager.GetString("FlagMethodArguments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The name of this method is too short to be meaningful..
         /// </summary>
         public static string MethodNameNotMeaningful {

--- a/CleanCode/src/CleanCode/Resources/Warnings.resx
+++ b/CleanCode/src/CleanCode/Resources/Warnings.resx
@@ -138,4 +138,7 @@
   <data name="MethodNameNotMeaningful" xml:space="preserve">
     <value>The name of this method is too short to be meaningful.</value>
   </data>
+  <data name="FlagMethodArguments" xml:space="preserve">
+    <value>This method does more than one thing. Passing a boolean into a function is a truly terrible practice.</value>
+  </data>
 </root>

--- a/CleanCode/src/CleanCode/Settings/CleanCodeSettings.cs
+++ b/CleanCode/src/CleanCode/Settings/CleanCodeSettings.cs
@@ -69,5 +69,10 @@ namespace CleanCode.Settings
         public bool MethodNameNotMeaningfulMinimumEnabled { get; set; }
         [SettingsEntry(4, "MethodNameNotMeaningfulMinimum")]
         public int MethodNameNotMeaningfulMinimum { get; set; }
+
+        [SettingsEntry(0, "FlagMethodArgumentsMinimum")]
+        public int FlagMethodArgumentsMinimum { get; set; }
+        [SettingsEntry(true, "FlagMethodArgumentsEnabled")]
+        public bool FlagMethodArgumentsEnabled { get; set; }
     }
 }


### PR DESCRIPTION
Based on The "Clean Code" book, passed a boolean into a function is a bad practice to avoid, because functions with flags arguments do one than more thing, one if the flag is true and another if the flag is false.