### PR TITLE
Update for ReSharper 2017.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #################
 ## Visual Studio
 #################
+.vs/
 
 # User-specific files
 *.suo

--- a/CleanCode/src/CleanCode.nuspec
+++ b/CleanCode/src/CleanCode.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>CleanCode.CleanCode</id>
-    <version>5.1.0</version>
+    <version>5.2.0</version>
     <title>Clean Code</title>
     <authors>Hadi Hariri, Matt Ellis, SuperJMN</authors>
     <owners>Hadi Hariri, Matt Ellis</owners>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Automates some of the concepts in Uncle Bob's Clean Code book</description>
     <releaseNotes>
+&#8226; Updated to ReSharper 2017.2
+
+From 5.1.0:
 &#8226; Updated to ReSharper 2017.1
 
 From 5.0.3:
@@ -34,9 +37,9 @@ From 4.0.0:
 &#8226; Suggestion highlight if class has too many methods
 &#8226; Suggestion highlight if method has too many statements
 </releaseNotes>
-    <copyright>Copyright 2014-2016 Hadi Hariri and Contributors</copyright>
+    <copyright>Copyright 2014-2017 Hadi Hariri and Contributors</copyright>
     <dependencies>
-      <dependency id="Wave" version="[8.0]" />
+      <dependency id="Wave" version="[9.0]" />
     </dependencies>
     <tags>clean code</tags>
   </metadata>

--- a/CleanCode/src/CleanCode.nuspec
+++ b/CleanCode/src/CleanCode.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>CleanCode.CleanCode</id>
-    <version>5.2.0</version>
+    <version>5.3.0</version>
     <title>Clean Code</title>
     <authors>Hadi Hariri, Matt Ellis, SuperJMN</authors>
     <owners>Hadi Hariri, Matt Ellis</owners>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Automates some of the concepts in Uncle Bob's Clean Code book</description>
     <releaseNotes>
+&#8226; Updated to ReSharper 2017.3
+
+From 5.2.0:
 &#8226; Updated to ReSharper 2017.2
 
 From 5.1.0:
@@ -39,7 +42,7 @@ From 4.0.0:
 </releaseNotes>
     <copyright>Copyright 2014-2017 Hadi Hariri and Contributors</copyright>
     <dependencies>
-      <dependency id="Wave" version="[9.0]" />
+      <dependency id="Wave" version="[11.0]" />
     </dependencies>
     <tags>clean code</tags>
   </metadata>

--- a/CleanCode/src/CleanCode/CleanCode.csproj
+++ b/CleanCode/src/CleanCode/CleanCode.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170530.0\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props" Condition="Exists('..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170530.0\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -14,7 +15,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>aa44b150</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,218 +38,142 @@
   <ItemGroup>
     <Reference Include="antlr.runtime, Version=2.7.7.1, Culture=neutral, PublicKeyToken=0f493c87b190d7e9, processorArchitecture=MSIL">
       <HintPath>..\packages\Antlr2.Runtime.2.7.7.02\lib\antlr.runtime.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="Appccelerate.Fundamentals, Version=2.3.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Appccelerate.StateMachine.JetBrains.2.2.0.1\lib\net45\Appccelerate.Fundamentals.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Appccelerate.StateMachine, Version=2.2.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Appccelerate.StateMachine.JetBrains.2.2.0.1\lib\net45\Appccelerate.StateMachine.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Appccelerate.StateMachine, Version=3.3.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Appccelerate.StateMachine.3.3.0\lib\netstandard1.0\Appccelerate.StateMachine.dll</HintPath>
     </Reference>
     <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
       <HintPath>..\packages\xmlrpcnet.2.5.0\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="DevExpress.Data.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20150224.0\lib\Net\DevExpress.Data.v7.1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.Data.v7.1.dll</HintPath>
     </Reference>
     <Reference Include="DevExpress.Utils.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20150224.0\lib\Net\DevExpress.Utils.v7.1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.Utils.v7.1.dll</HintPath>
     </Reference>
     <Reference Include="DevExpress.XtraEditors.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20150224.0\lib\Net\DevExpress.XtraEditors.v7.1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.XtraEditors.v7.1.dll</HintPath>
     </Reference>
     <Reference Include="DevExpress.XtraTreeList.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20150224.0\lib\Net\DevExpress.XtraTreeList.v7.1.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.XtraTreeList.v7.1.dll</HintPath>
     </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6144.33521, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpZipLib.JetBrains.Stripped.0.87.20161027.6\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
     </Reference>
-    <Reference Include="Ionic.Zip.Reduced, Version=1.9.1.8, Culture=neutral, PublicKeyToken=edbe51ad942a3f5c, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6410.32456, Culture=neutral, PublicKeyToken=af5372d9166ac06b, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.SharpZipLib.Stripped.0.87.20170720.14\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
-    <Reference Include="JetBrains.Annotations, Version=10.4.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.4.0\lib\net\JetBrains.Annotations.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JetBrains.Annotations, Version=11.0.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.11.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
     <Reference Include="JetBrains.MSBuild.Logger, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1982a8b0ca24c5dc, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.MSBuild.Logger.1.0.20170130.0\lib\net\JetBrains.MSBuild.Logger.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\JetBrains.Platform.MSBuild.Logger.1.0.20170331.0\lib\net\JetBrains.MSBuild.Logger.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="JetBrains.System.Reflection.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=4fea49dae943e013, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.System.Reflection.Metadata.1.0.0\lib\net45\JetBrains.System.Reflection.Metadata.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\JetBrains.System.Reflection.Metadata.20170417.0.0.0\lib\net45\JetBrains.System.Reflection.Metadata.dll</HintPath>
     </Reference>
-    <Reference Include="MahApps.Metro, Version=1.3.0.0, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MahApps.Metro.1.3.1\lib\net45\MahApps.Metro.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="JetBrains.Toolset.ScriptSourcesCompiler.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1982a8b0ca24c5dc, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Toolset.ScriptSourcesCompiler.Interface.1.0.20170420.0\lib\net\JetBrains.Toolset.ScriptSourcesCompiler.Interface.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="MahApps.Metro, Version=1.5.0.23, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.MahApps.Metro.1.5.0.1\lib\net45\MahApps.Metro.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Deployment.Compression, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.Microsoft.Deployment.Compression.Cab.2.0.20140304.0\lib\Microsoft.Deployment.Compression.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\JetBrains.Microsoft.Deployment.Compression.Cab.3.11.0\lib\net20\Microsoft.Deployment.Compression.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Deployment.Compression.Cab, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.Microsoft.Deployment.Compression.Cab.2.0.20140304.0\lib\Microsoft.Deployment.Compression.Cab.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\JetBrains.Microsoft.Deployment.Compression.Cab.3.11.0\lib\net20\Microsoft.Deployment.Compression.Cab.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin.FileSystems, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.FileSystems.3.0.1\lib\net45\Microsoft.Owin.FileSystems.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin.StaticFiles, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.StaticFiles.3.0.1\lib\net45\Microsoft.Owin.StaticFiles.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Windows7APICodePack.JetBrains.Stripped.1.1.20150225.0\lib\Net\Microsoft.WindowsAPICodePack.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Windows7APICodePack.JetBrains.Stripped.1.1.20150225.0\lib\Net\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Commands, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Commands, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Commands.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Common, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Common, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Common.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Configuration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.ContentModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.ContentModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Configuration, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.NuGet.Core.2.14.1\lib\net40-Client\NuGet.Core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="NuGet.DependencyResolver.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.DependencyResolver.Core, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Frameworks.4.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Frameworks, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Frameworks.4.3.0.10000\lib\net45\NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.LibraryModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.LibraryModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.LibraryModel, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.PackageManagement, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.PackageManagement.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.PackageManagement, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Packaging, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Packaging.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Packaging.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Packaging.Core.Types.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.ProjectModel, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.ProjectManagement, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.ProjectManagement.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Protocol, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.ProjectModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.ProjectModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Resolver, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Protocol.Core.Types, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.Core.Types.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Protocol.Core.v2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.Core.v2.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Protocol.Core.v3, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.Core.v3.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Protocol.VisualStudio, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Protocol.VisualStudio.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Repositories, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Repositories.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Resolver, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.Resolver.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.RuntimeModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.0.0\lib\net45\NuGet.RuntimeModel.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Versioning.4.0.0\lib\net45\NuGet.Versioning.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="NuGet.Versioning, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Versioning.4.3.0.10000\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="NVelocity, Version=1.0.3.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\NVelocity.1.0.3\lib\NVelocity.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="SharpCompress, Version=0.11.6.0, Culture=neutral, PublicKeyToken=beaf6f427e128133, processorArchitecture=MSIL">
       <HintPath>..\packages\sharpcompress.0.11.6\lib\net40\SharpCompress.dll</HintPath>
-      <Private>True</Private>
+    </Reference>
+    <Reference Include="Should, Version=1.0.0.0, Culture=neutral, PublicKeyToken=e62b29fcbcda8b16, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>
     <Reference Include="Sprache, Version=2.1.0.0, Culture=neutral, PublicKeyToken=f763bc865f9b2be9, processorArchitecture=MSIL">
       <HintPath>..\packages\Sprache.JetBrains.2.1.0\lib\net40\Sprache.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -260,7 +186,7 @@
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.System.Windows.Interactivity.3.0.40218\lib\System.Windows.Interactivity.dll</HintPath>
+      <HintPath>..\packages\JetBrains.System.Windows.Interactivity.3.0.40218.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xaml" />
@@ -272,24 +198,22 @@
     <Reference Include="System.Xml" />
     <Reference Include="Vestris.ResourceLib, Version=1.4.33.0, Culture=neutral, PublicKeyToken=ec632d8ba5e5750d, processorArchitecture=MSIL">
       <HintPath>..\packages\Vestris.ResourceLib.JetBrains.1.4.20150303.0\lib\Net\Vestris.ResourceLib.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="WpfContrib, Version=1.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.WpfContrib.2.0.20150225.0\lib\Net\WpfContrib.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\JetBrains.Platform.Lib.WpfContrib.2.0.20170610\lib\net20\WpfContrib.dll</HintPath>
     </Reference>
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.JetBrains.1.9.2\lib\net20\xunit.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="xunit.runner.utility.net35, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.runner.utility.2.2.0\lib\net35\xunit.runner.utility.net35.dll</HintPath>
-      <Private>True</Private>
+    </Reference>
+    <Reference Include="YamlDotNet, Version=4.2.1.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.Signed.4.2.1\lib\net35\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -373,37 +297,46 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170530.0\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170530.0\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props'))" />
     <Error Condition="!Exists('..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Shell.109.0.20170824.130529\build\JetBrains.Platform.Core.Shell.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Shell.109.0.20170824.130529\build\JetBrains.Platform.Core.Shell.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Text.109.0.20170824.131327\build\JetBrains.Platform.Core.Text.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Text.109.0.20170824.131327\build\JetBrains.Platform.Core.Text.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.CommandLine.109.0.20170824.131327\build\JetBrains.Platform.Interop.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.CommandLine.109.0.20170824.131327\build\JetBrains.Platform.Interop.CommandLine.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.RdProtocol.109.0.20170824.131327\build\JetBrains.Platform.RdProtocol.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.RdProtocol.109.0.20170824.131327\build\JetBrains.Platform.RdProtocol.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Ide.109.0.20170824.131327\build\JetBrains.Platform.Core.Ide.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Ide.109.0.20170824.131327\build\JetBrains.Platform.Core.Ide.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Sdk.109.0.20170824.131327\build\JetBrains.Platform.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Sdk.109.0.20170824.131327\build\JetBrains.Platform.Sdk.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Tests.Framework.109.0.20170824.131327\build\JetBrains.Platform.Tests.Framework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Tests.Framework.109.0.20170824.131327\build\JetBrains.Platform.Tests.Framework.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Shell.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Shell.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Shell.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Shell.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Text.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Text.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Text.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Text.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Ide.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Ide.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Ide.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Ide.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Tasks.109.0.20170824.132357\build\JetBrains.Psi.Features.Tasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Tasks.109.0.20170824.132357\build\JetBrains.Psi.Features.Tasks.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.UIInteractive.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UIInteractive.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.UIInteractive.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.src.109.0.20170824.132357\build\JetBrains.Psi.Features.src.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.src.109.0.20170824.132357\build\JetBrains.Psi.Features.src.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UnitTesting.109.0.20170824.132357\build\JetBrains.Psi.Features.UnitTesting.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UnitTesting.109.0.20170824.132357\build\JetBrains.Psi.Features.UnitTesting.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.test.Framework.109.0.20170824.132357\build\JetBrains.Psi.Features.test.Framework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.test.Framework.109.0.20170824.132357\build\JetBrains.Psi.Features.test.Framework.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.SDK.Internal.109.0.20170824.140122\build\JetBrains.ReSharper.SDK.Internal.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.SDK.Internal.109.0.20170824.140122\build\JetBrains.ReSharper.SDK.Internal.targets'))" />
   </Target>
   <Import Project="..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets" Condition="Exists('..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Shell.108.0.20170402.74924\build\JetBrains.Platform.Core.Shell.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Text.108.0.20170402.75356\build\JetBrains.Platform.Core.Text.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets" Condition="Exists('..\packages\JetBrains.Platform.RdProtocol.108.0.20170402.75356\build\JetBrains.Platform.RdProtocol.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Ide.108.0.20170402.75356\build\JetBrains.Platform.Core.Ide.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.108.0.20170402.75356\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets" Condition="Exists('..\packages\JetBrains.Platform.Symbols.108.0.20170402.75356\build\JetBrains.Platform.Symbols.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets" Condition="Exists('..\packages\JetBrains.Platform.Tests.Framework.108.0.20170402.75356\build\JetBrains.Platform.Tests.Framework.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Tasks.108.0.20170403.124150\build\JetBrains.Psi.Features.Tasks.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Core.108.0.20170403.124150\build\JetBrains.Psi.Features.Core.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.src.108.0.20170403.124150\build\JetBrains.Psi.Features.src.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UnitTesting.108.0.20170403.124150\build\JetBrains.Psi.Features.UnitTesting.Targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets" Condition="Exists('..\packages\JetBrains.Psi.Features.test.Framework.108.0.20170403.124150\build\JetBrains.Psi.Features.test.Framework.Targets')" />
-  <Import Project="..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Internal.108.0.20170403.131543\build\JetBrains.ReSharper.SDK.Internal.Targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Shell.109.0.20170824.130529\build\JetBrains.Platform.Core.Shell.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Shell.109.0.20170824.130529\build\JetBrains.Platform.Core.Shell.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Text.109.0.20170824.131327\build\JetBrains.Platform.Core.Text.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Text.109.0.20170824.131327\build\JetBrains.Platform.Core.Text.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.CommandLine.109.0.20170824.131327\build\JetBrains.Platform.Interop.CommandLine.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.CommandLine.109.0.20170824.131327\build\JetBrains.Platform.Interop.CommandLine.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.RdProtocol.109.0.20170824.131327\build\JetBrains.Platform.RdProtocol.targets" Condition="Exists('..\packages\JetBrains.Platform.RdProtocol.109.0.20170824.131327\build\JetBrains.Platform.RdProtocol.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Ide.109.0.20170824.131327\build\JetBrains.Platform.Core.Ide.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Ide.109.0.20170824.131327\build\JetBrains.Platform.Core.Ide.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Sdk.109.0.20170824.131327\build\JetBrains.Platform.Sdk.targets" Condition="Exists('..\packages\JetBrains.Platform.Sdk.109.0.20170824.131327\build\JetBrains.Platform.Sdk.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Tests.Framework.109.0.20170824.131327\build\JetBrains.Platform.Tests.Framework.targets" Condition="Exists('..\packages\JetBrains.Platform.Tests.Framework.109.0.20170824.131327\build\JetBrains.Platform.Tests.Framework.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Shell.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Shell.targets" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Shell.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Shell.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Text.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Text.targets" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Text.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Text.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Ide.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Ide.targets" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Ide.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Ide.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Tasks.109.0.20170824.132357\build\JetBrains.Psi.Features.Tasks.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Tasks.109.0.20170824.132357\build\JetBrains.Psi.Features.Tasks.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.Core.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.Core.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UIInteractive.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.UIInteractive.Core.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.UIInteractive.Core.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.src.109.0.20170824.132357\build\JetBrains.Psi.Features.src.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.src.109.0.20170824.132357\build\JetBrains.Psi.Features.src.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UnitTesting.109.0.20170824.132357\build\JetBrains.Psi.Features.UnitTesting.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UnitTesting.109.0.20170824.132357\build\JetBrains.Psi.Features.UnitTesting.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.test.Framework.109.0.20170824.132357\build\JetBrains.Psi.Features.test.Framework.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.test.Framework.109.0.20170824.132357\build\JetBrains.Psi.Features.test.Framework.targets')" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.Internal.109.0.20170824.140122\build\JetBrains.ReSharper.SDK.Internal.targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Internal.109.0.20170824.140122\build\JetBrains.ReSharper.SDK.Internal.targets')" />
 </Project>

--- a/CleanCode/src/CleanCode/CleanCode.csproj
+++ b/CleanCode/src/CleanCode/CleanCode.csproj
@@ -1,6 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170530.0\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props" Condition="Exists('..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170530.0\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props')" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.Internal.111.0.20171219.91646\build\net45\JetBrains.ReSharper.SDK.Internal.props" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Internal.111.0.20171219.91646\build\net45\JetBrains.ReSharper.SDK.Internal.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.VisualStudio.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.VisualStudio.props" Condition="Exists('..\packages\JetBrains.Psi.Features.VisualStudio.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.VisualStudio.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UIInteractive.Features.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Features.props" Condition="Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Features.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Features.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.test.Framework.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.test.Framework.props" Condition="Exists('..\packages\JetBrains.Psi.Features.test.Framework.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.test.Framework.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UnitTesting.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UnitTesting.props" Condition="Exists('..\packages\JetBrains.Psi.Features.UnitTesting.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UnitTesting.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.props" Condition="Exists('..\packages\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Diagramming.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Diagramming.props" Condition="Exists('..\packages\JetBrains.Psi.Features.Diagramming.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Diagramming.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UIInteractive.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Core.props" Condition="Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Core.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.SolutionBuilder.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.SolutionBuilder.props" Condition="Exists('..\packages\JetBrains.Psi.Features.SolutionBuilder.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.SolutionBuilder.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.src.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.src.props" Condition="Exists('..\packages\JetBrains.Psi.Features.src.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.src.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Core.props" Condition="Exists('..\packages\JetBrains.Psi.Features.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Core.props')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Tasks.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Tasks.props" Condition="Exists('..\packages\JetBrains.Psi.Features.Tasks.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Tasks.props')" />
+  <Import Project="..\packages\JetBrains.Platform.VisualStudio.111.0.20171218.132839\build\net45\JetBrains.Platform.VisualStudio.props" Condition="Exists('..\packages\JetBrains.Platform.VisualStudio.111.0.20171218.132839\build\net45\JetBrains.Platform.VisualStudio.props')" />
+  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Ide.props" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Ide.props')" />
+  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Text.props" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Text.props')" />
+  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Shell.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Shell.props" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Shell.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Shell.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Tests.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Tests.Framework.props" Condition="Exists('..\packages\JetBrains.Platform.Tests.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Tests.Framework.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Sdk.111.0.20171218.132839\build\net45\JetBrains.Platform.Sdk.props" Condition="Exists('..\packages\JetBrains.Platform.Sdk.111.0.20171218.132839\build\net45\JetBrains.Platform.Sdk.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.props" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.props" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Ide.props" Condition="Exists('..\packages\JetBrains.Platform.Core.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Ide.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.MsBuild.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.MsBuild.props" Condition="Exists('..\packages\JetBrains.Platform.Core.MsBuild.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.MsBuild.props')" />
+  <Import Project="..\packages\JetBrains.Platform.RdProtocol.111.0.20171218.132839\build\net45\JetBrains.Platform.RdProtocol.props" Condition="Exists('..\packages\JetBrains.Platform.RdProtocol.111.0.20171218.132839\build\net45\JetBrains.Platform.RdProtocol.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.CommandLine.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.CommandLine.props" Condition="Exists('..\packages\JetBrains.Platform.Interop.CommandLine.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.CommandLine.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Text.props" Condition="Exists('..\packages\JetBrains.Platform.Core.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Text.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Shell.111.0.20171218.132440\build\net45\JetBrains.Platform.Core.Shell.props" Condition="Exists('..\packages\JetBrains.Platform.Core.Shell.111.0.20171218.132440\build\net45\JetBrains.Platform.Core.Shell.props')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Framework.props" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Framework.props')" />
+  <Import Project="..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170904.2\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props" Condition="Exists('..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170904.2\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -35,187 +62,6 @@
     <WarningLevel>4</WarningLevel>
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="antlr.runtime, Version=2.7.7.1, Culture=neutral, PublicKeyToken=0f493c87b190d7e9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Antlr2.Runtime.2.7.7.02\lib\antlr.runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="Appccelerate.StateMachine, Version=3.3.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Appccelerate.StateMachine.3.3.0\lib\netstandard1.0\Appccelerate.StateMachine.dll</HintPath>
-    </Reference>
-    <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
-      <HintPath>..\packages\xmlrpcnet.2.5.0\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
-    </Reference>
-    <Reference Include="DevExpress.Data.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.Data.v7.1.dll</HintPath>
-    </Reference>
-    <Reference Include="DevExpress.Utils.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.Utils.v7.1.dll</HintPath>
-    </Reference>
-    <Reference Include="DevExpress.XtraEditors.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.XtraEditors.v7.1.dll</HintPath>
-    </Reference>
-    <Reference Include="DevExpress.XtraTreeList.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.XtraTreeList.v7.1.dll</HintPath>
-    </Reference>
-    <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
-    </Reference>
-    <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6410.32456, Culture=neutral, PublicKeyToken=af5372d9166ac06b, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.SharpZipLib.Stripped.0.87.20170720.14\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
-    </Reference>
-    <Reference Include="JetBrains.Annotations, Version=11.0.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.11.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>
-    </Reference>
-    <Reference Include="JetBrains.MSBuild.Logger, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1982a8b0ca24c5dc, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.MSBuild.Logger.1.0.20170331.0\lib\net\JetBrains.MSBuild.Logger.dll</HintPath>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="JetBrains.System.Reflection.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=4fea49dae943e013, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.System.Reflection.Metadata.20170417.0.0.0\lib\net45\JetBrains.System.Reflection.Metadata.dll</HintPath>
-    </Reference>
-    <Reference Include="JetBrains.Toolset.ScriptSourcesCompiler.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1982a8b0ca24c5dc, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Toolset.ScriptSourcesCompiler.Interface.1.0.20170420.0\lib\net\JetBrains.Toolset.ScriptSourcesCompiler.Interface.dll</HintPath>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="MahApps.Metro, Version=1.5.0.23, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.MahApps.Metro.1.5.0.1\lib\net45\MahApps.Metro.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Deployment.Compression, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Microsoft.Deployment.Compression.Cab.3.11.0\lib\net20\Microsoft.Deployment.Compression.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Deployment.Compression.Cab, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Microsoft.Deployment.Compression.Cab.3.11.0\lib\net20\Microsoft.Deployment.Compression.Cab.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Owin.FileSystems, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.FileSystems.3.0.1\lib\net45\Microsoft.Owin.FileSystems.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Owin.StaticFiles, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.StaticFiles.3.0.1\lib\net45\Microsoft.Owin.StaticFiles.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Windows7APICodePack.JetBrains.Stripped.1.1.20150225.0\lib\Net\Microsoft.WindowsAPICodePack.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Windows7APICodePack.JetBrains.Stripped.1.1.20150225.0\lib\Net\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Commands, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Commands.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Common, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Configuration, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Core.2.14.1\lib\net40-Client\NuGet.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.DependencyResolver.Core, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Frameworks, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Frameworks.4.3.0.10000\lib\net45\NuGet.Frameworks.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.LibraryModel, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.LibraryModel.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.PackageManagement, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.PackageManagement.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Packaging, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Packaging.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Packaging.Core, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Packaging.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.ProjectModel, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.ProjectModel.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Protocol, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Protocol.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Resolver, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.3.0.10000\lib\net45\NuGet.Resolver.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=4.3.0.5, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.NuGet.Versioning.4.3.0.10000\lib\net45\NuGet.Versioning.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="NVelocity, Version=1.0.3.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\NVelocity.1.0.3\lib\NVelocity.dll</HintPath>
-    </Reference>
-    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
-    </Reference>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-    <Reference Include="SharpCompress, Version=0.11.6.0, Culture=neutral, PublicKeyToken=beaf6f427e128133, processorArchitecture=MSIL">
-      <HintPath>..\packages\sharpcompress.0.11.6\lib\net40\SharpCompress.dll</HintPath>
-    </Reference>
-    <Reference Include="Should, Version=1.0.0.0, Culture=neutral, PublicKeyToken=e62b29fcbcda8b16, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Should.1.1.20\lib\Should.dll</HintPath>
-    </Reference>
-    <Reference Include="Sprache, Version=2.1.0.0, Culture=neutral, PublicKeyToken=f763bc865f9b2be9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sprache.JetBrains.2.1.0\lib\net40\Sprache.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Security" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.System.Windows.Interactivity.3.0.40218.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Vestris.ResourceLib, Version=1.4.33.0, Culture=neutral, PublicKeyToken=ec632d8ba5e5750d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Vestris.ResourceLib.JetBrains.1.4.20150303.0\lib\Net\Vestris.ResourceLib.dll</HintPath>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="WpfContrib, Version=1.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Platform.Lib.WpfContrib.2.0.20170610\lib\net20\WpfContrib.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.JetBrains.1.9.2\lib\net20\xunit.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="xunit.runner.utility.net35, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.runner.utility.2.2.0\lib\net35\xunit.runner.utility.net35.dll</HintPath>
-    </Reference>
-    <Reference Include="YamlDotNet, Version=4.2.1.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
-      <HintPath>..\packages\YamlDotNet.Signed.4.2.1\lib\net35\YamlDotNet.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="CleanCodeHighlightingGroupIds.cs" />
     <Compile Include="Features\ChainedReferences\MaximumChainedReferencesHighlighting.cs" />
@@ -290,6 +136,188 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="antlr.runtime, Version=2.7.7.1, Culture=neutral, PublicKeyToken=0f493c87b190d7e9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr2.Runtime.2.7.7.02\lib\antlr.runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Appccelerate.StateMachine, Version=3.3.0.0, Culture=neutral, PublicKeyToken=917bca444d1f2b4c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Appccelerate.StateMachine.3.3.0\lib\netstandard1.0\Appccelerate.StateMachine.dll</HintPath>
+    </Reference>
+    <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
+      <HintPath>..\packages\xmlrpcnet.2.5.0\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
+    </Reference>
+    <Reference Include="DevExpress.Data.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.Data.v7.1.dll</HintPath>
+    </Reference>
+    <Reference Include="DevExpress.Utils.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.Utils.v7.1.dll</HintPath>
+    </Reference>
+    <Reference Include="DevExpress.XtraEditors.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.XtraEditors.v7.1.dll</HintPath>
+    </Reference>
+    <Reference Include="DevExpress.XtraTreeList.v7.1, Version=7.1.3.0, Culture=neutral, PublicKeyToken=ac81f19954537d54, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.Lib.DevExpress.2.0.20170610\lib\net20\DevExpress.XtraTreeList.v7.1.dll</HintPath>
+    </Reference>
+    <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.6410.32456, Culture=neutral, PublicKeyToken=af5372d9166ac06b, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.SharpZipLib.Stripped.0.87.20170720.14\lib\net40\ICSharpCode.SharpZipLib.dll</HintPath>
+    </Reference>
+    <Reference Include="JetBrains.Annotations, Version=11.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.11.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="JetBrains.MSBuild.Logger.Api, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1982a8b0ca24c5dc, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.MSBuild.Logger.Api.1.0.20170809\lib\net\JetBrains.MSBuild.Logger.Api.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="JetBrains.System.Reflection.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=4fea49dae943e013, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.System.Reflection.Metadata.20170417.0.0.0\lib\net45\JetBrains.System.Reflection.Metadata.dll</HintPath>
+    </Reference>
+    <Reference Include="JetBrains.Toolset.ScriptSourcesCompiler.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=1982a8b0ca24c5dc, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Toolset.ScriptSourcesCompiler.Interface.1.0.20170420.0\lib\net\JetBrains.Toolset.ScriptSourcesCompiler.Interface.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="MahApps.Metro, Version=1.5.0.23, Culture=neutral, PublicKeyToken=f4fb5a3c4d1e5b4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.MahApps.Metro.1.5.0.1\lib\net45\MahApps.Metro.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Deployment.Compression, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Microsoft.Deployment.Compression.Cab.3.11.0\lib\net20\Microsoft.Deployment.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Deployment.Compression.Cab, Version=3.0.0.0, Culture=neutral, PublicKeyToken=ce35f76fcda82bad, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Microsoft.Deployment.Compression.Cab.3.11.0\lib\net20\Microsoft.Deployment.Compression.Cab.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.FileSystems, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.FileSystems.3.0.1\lib\net45\Microsoft.Owin.FileSystems.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.StaticFiles, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.StaticFiles.3.0.1\lib\net45\Microsoft.Owin.StaticFiles.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\JetBrains.Platform.Lib.VisualStudio.AnyVs.ShellInterop.PrivateBuild.2.0.20141005.1\lib\net20\Microsoft.VisualStudio.Shell.Interop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Windows7APICodePack.JetBrains.Stripped.1.1.20150225.0\lib\Net\Microsoft.WindowsAPICodePack.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Windows7APICodePack.JetBrains.Stripped.1.1.20150225.0\lib\Net\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Commands, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.Commands.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Common, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Configuration, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Core.2.14.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.DependencyResolver.Core, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.DependencyResolver.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Frameworks, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Frameworks.4.5.0.0\lib\net45\NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.LibraryModel, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.LibraryModel.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.PackageManagement, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.PackageManagement.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Packaging, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Packaging.Core, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.Packaging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.ProjectModel, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.ProjectModel.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Protocol, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.Protocol.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Resolver, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Ultimate.4.5.0.0\lib\net45\NuGet.Resolver.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Versioning, Version=4.5.0.4, Culture=neutral, PublicKeyToken=5aaa11a165479571, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.NuGet.Versioning.4.5.0.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="NVelocity, Version=1.0.3.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\NVelocity.1.0.3\lib\NVelocity.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="SharpCompress, Version=0.11.6.0, Culture=neutral, PublicKeyToken=beaf6f427e128133, processorArchitecture=MSIL">
+      <HintPath>..\packages\sharpcompress.0.11.6\lib\net40\SharpCompress.dll</HintPath>
+    </Reference>
+    <Reference Include="Should, Version=1.0.0.0, Culture=neutral, PublicKeyToken=e62b29fcbcda8b16, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Should.1.1.20\lib\Should.dll</HintPath>
+    </Reference>
+    <Reference Include="Sprache, Version=2.1.0.0, Culture=neutral, PublicKeyToken=f763bc865f9b2be9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sprache.JetBrains.2.1.0\lib\net40\Sprache.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.System.Windows.Interactivity.3.0.40218.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Vestris.ResourceLib, Version=1.4.33.0, Culture=neutral, PublicKeyToken=ec632d8ba5e5750d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Vestris.ResourceLib.JetBrains.1.4.20150303.0\lib\Net\Vestris.ResourceLib.dll</HintPath>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="WpfContrib, Version=1.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Platform.Lib.WpfContrib.2.0.20170610\lib\net20\WpfContrib.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.JetBrains.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.runner.utility.net35, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.runner.utility.2.2.0\lib\net35\xunit.runner.utility.net35.dll</HintPath>
+    </Reference>
+    <Reference Include="YamlDotNet, Version=4.2.1.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.Signed.4.2.1\lib\net35\YamlDotNet.dll</HintPath>
+    </Reference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets" Condition="Exists('..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -297,46 +325,89 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Antlr2.Tools.2.7.6.4\build\Antlr2.Tools.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170530.0\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170530.0\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170904.2\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.2.0.20170904.2\build\JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask.Props'))" />
     <Error Condition="!Exists('..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Shell.109.0.20170824.130529\build\JetBrains.Platform.Core.Shell.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Shell.109.0.20170824.130529\build\JetBrains.Platform.Core.Shell.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Text.109.0.20170824.131327\build\JetBrains.Platform.Core.Text.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Text.109.0.20170824.131327\build\JetBrains.Platform.Core.Text.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.CommandLine.109.0.20170824.131327\build\JetBrains.Platform.Interop.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.CommandLine.109.0.20170824.131327\build\JetBrains.Platform.Interop.CommandLine.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.RdProtocol.109.0.20170824.131327\build\JetBrains.Platform.RdProtocol.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.RdProtocol.109.0.20170824.131327\build\JetBrains.Platform.RdProtocol.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Ide.109.0.20170824.131327\build\JetBrains.Platform.Core.Ide.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Ide.109.0.20170824.131327\build\JetBrains.Platform.Core.Ide.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Sdk.109.0.20170824.131327\build\JetBrains.Platform.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Sdk.109.0.20170824.131327\build\JetBrains.Platform.Sdk.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.Tests.Framework.109.0.20170824.131327\build\JetBrains.Platform.Tests.Framework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Tests.Framework.109.0.20170824.131327\build\JetBrains.Platform.Tests.Framework.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Shell.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Shell.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Shell.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Shell.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Text.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Text.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Text.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Text.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Ide.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Ide.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Ide.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Ide.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Tasks.109.0.20170824.132357\build\JetBrains.Psi.Features.Tasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Tasks.109.0.20170824.132357\build\JetBrains.Psi.Features.Tasks.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.Core.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.UIInteractive.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UIInteractive.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.UIInteractive.Core.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.src.109.0.20170824.132357\build\JetBrains.Psi.Features.src.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.src.109.0.20170824.132357\build\JetBrains.Psi.Features.src.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UnitTesting.109.0.20170824.132357\build\JetBrains.Psi.Features.UnitTesting.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UnitTesting.109.0.20170824.132357\build\JetBrains.Psi.Features.UnitTesting.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.test.Framework.109.0.20170824.132357\build\JetBrains.Psi.Features.test.Framework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.test.Framework.109.0.20170824.132357\build\JetBrains.Psi.Features.test.Framework.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.SDK.Internal.109.0.20170824.140122\build\JetBrains.ReSharper.SDK.Internal.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.SDK.Internal.109.0.20170824.140122\build\JetBrains.ReSharper.SDK.Internal.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Framework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Framework.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Shell.111.0.20171218.132440\build\net45\JetBrains.Platform.Core.Shell.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Shell.111.0.20171218.132440\build\net45\JetBrains.Platform.Core.Shell.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Shell.111.0.20171218.132440\build\net45\JetBrains.Platform.Core.Shell.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Shell.111.0.20171218.132440\build\net45\JetBrains.Platform.Core.Shell.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Text.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Text.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Text.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Text.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.CommandLine.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.CommandLine.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.CommandLine.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.CommandLine.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.CommandLine.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.CommandLine.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.CommandLine.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.CommandLine.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.RdProtocol.111.0.20171218.132839\build\net45\JetBrains.Platform.RdProtocol.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.RdProtocol.111.0.20171218.132839\build\net45\JetBrains.Platform.RdProtocol.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.RdProtocol.111.0.20171218.132839\build\net45\JetBrains.Platform.RdProtocol.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.RdProtocol.111.0.20171218.132839\build\net45\JetBrains.Platform.RdProtocol.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.MsBuild.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.MsBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.MsBuild.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.MsBuild.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.MsBuild.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.MsBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.MsBuild.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.MsBuild.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Ide.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Ide.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Core.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Ide.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Core.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Ide.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Sdk.111.0.20171218.132839\build\net45\JetBrains.Platform.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Sdk.111.0.20171218.132839\build\net45\JetBrains.Platform.Sdk.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Sdk.111.0.20171218.132839\build\net45\JetBrains.Platform.Sdk.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Sdk.111.0.20171218.132839\build\net45\JetBrains.Platform.Sdk.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Tests.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Tests.Framework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Tests.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Tests.Framework.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.Tests.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Tests.Framework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.Tests.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Tests.Framework.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Shell.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Shell.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Shell.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Shell.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Shell.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Shell.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Shell.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Shell.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Text.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Text.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Text.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Text.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Ide.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Ide.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.UIInteractive.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Ide.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.UIInteractive.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Ide.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.VisualStudio.111.0.20171218.132839\build\net45\JetBrains.Platform.VisualStudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.VisualStudio.111.0.20171218.132839\build\net45\JetBrains.Platform.VisualStudio.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Platform.VisualStudio.111.0.20171218.132839\build\net45\JetBrains.Platform.VisualStudio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Platform.VisualStudio.111.0.20171218.132839\build\net45\JetBrains.Platform.VisualStudio.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Tasks.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Tasks.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Tasks.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Tasks.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Tasks.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Tasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Tasks.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Tasks.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Core.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.src.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.src.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.src.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.src.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.src.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.src.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.src.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.src.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.SolutionBuilder.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.SolutionBuilder.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.SolutionBuilder.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.SolutionBuilder.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.SolutionBuilder.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.SolutionBuilder.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.SolutionBuilder.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.SolutionBuilder.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UIInteractive.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Core.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UIInteractive.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Core.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Diagramming.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Diagramming.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Diagramming.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Diagramming.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.Diagramming.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Diagramming.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.Diagramming.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Diagramming.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UnitTesting.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UnitTesting.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UnitTesting.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UnitTesting.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UnitTesting.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UnitTesting.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UnitTesting.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UnitTesting.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.test.Framework.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.test.Framework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.test.Framework.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.test.Framework.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.test.Framework.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.test.Framework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.test.Framework.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.test.Framework.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Features.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Features.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UIInteractive.Features.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Features.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Features.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Features.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.UIInteractive.Features.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Features.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.VisualStudio.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.VisualStudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.VisualStudio.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.VisualStudio.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.Psi.Features.VisualStudio.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.VisualStudio.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.Psi.Features.VisualStudio.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.VisualStudio.targets'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.SDK.Internal.111.0.20171219.91646\build\net45\JetBrains.ReSharper.SDK.Internal.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.SDK.Internal.111.0.20171219.91646\build\net45\JetBrains.ReSharper.SDK.Internal.props'))" />
+    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.SDK.Internal.111.0.20171219.91646\build\net45\JetBrains.ReSharper.SDK.Internal.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.SDK.Internal.111.0.20171219.91646\build\net45\JetBrains.ReSharper.SDK.Internal.targets'))" />
   </Target>
   <Import Project="..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets" Condition="Exists('..\packages\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.2.0.20151217.1\build\JetBrains.Build.Platform.Tasks.ThemedIconsPacker.Targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Shell.109.0.20170824.130529\build\JetBrains.Platform.Core.Shell.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Shell.109.0.20170824.130529\build\JetBrains.Platform.Core.Shell.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Text.109.0.20170824.131327\build\JetBrains.Platform.Core.Text.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Text.109.0.20170824.131327\build\JetBrains.Platform.Core.Text.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.CommandLine.109.0.20170824.131327\build\JetBrains.Platform.Interop.CommandLine.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.CommandLine.109.0.20170824.131327\build\JetBrains.Platform.Interop.CommandLine.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.RdProtocol.109.0.20170824.131327\build\JetBrains.Platform.RdProtocol.targets" Condition="Exists('..\packages\JetBrains.Platform.RdProtocol.109.0.20170824.131327\build\JetBrains.Platform.RdProtocol.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Core.Ide.109.0.20170824.131327\build\JetBrains.Platform.Core.Ide.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Ide.109.0.20170824.131327\build\JetBrains.Platform.Core.Ide.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.109.0.20170824.131327\build\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Sdk.109.0.20170824.131327\build\JetBrains.Platform.Sdk.targets" Condition="Exists('..\packages\JetBrains.Platform.Sdk.109.0.20170824.131327\build\JetBrains.Platform.Sdk.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.Tests.Framework.109.0.20170824.131327\build\JetBrains.Platform.Tests.Framework.targets" Condition="Exists('..\packages\JetBrains.Platform.Tests.Framework.109.0.20170824.131327\build\JetBrains.Platform.Tests.Framework.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Shell.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Shell.targets" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Shell.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Shell.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Text.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Text.targets" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Text.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Text.targets')" />
-  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Ide.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Ide.targets" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Ide.109.0.20170824.131327\build\JetBrains.Platform.UIInteractive.Ide.targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.Tasks.109.0.20170824.132357\build\JetBrains.Psi.Features.Tasks.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Tasks.109.0.20170824.132357\build\JetBrains.Psi.Features.Tasks.targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.Core.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.Core.targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.UIInteractive.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.UIInteractive.Core.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Core.109.0.20170824.132357\build\JetBrains.Psi.Features.UIInteractive.Core.targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.src.109.0.20170824.132357\build\JetBrains.Psi.Features.src.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.src.109.0.20170824.132357\build\JetBrains.Psi.Features.src.targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.UnitTesting.109.0.20170824.132357\build\JetBrains.Psi.Features.UnitTesting.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UnitTesting.109.0.20170824.132357\build\JetBrains.Psi.Features.UnitTesting.targets')" />
-  <Import Project="..\packages\JetBrains.Psi.Features.test.Framework.109.0.20170824.132357\build\JetBrains.Psi.Features.test.Framework.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.test.Framework.109.0.20170824.132357\build\JetBrains.Psi.Features.test.Framework.targets')" />
-  <Import Project="..\packages\JetBrains.ReSharper.SDK.Internal.109.0.20170824.140122\build\JetBrains.ReSharper.SDK.Internal.targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Internal.109.0.20170824.140122\build\JetBrains.ReSharper.SDK.Internal.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Framework.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Shell.111.0.20171218.132440\build\net45\JetBrains.Platform.Core.Shell.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Shell.111.0.20171218.132440\build\net45\JetBrains.Platform.Core.Shell.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Text.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Text.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.CommandLine.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.CommandLine.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.CommandLine.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.CommandLine.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.RdProtocol.111.0.20171218.132839\build\net45\JetBrains.Platform.RdProtocol.targets" Condition="Exists('..\packages\JetBrains.Platform.RdProtocol.111.0.20171218.132839\build\net45\JetBrains.Platform.RdProtocol.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.MsBuild.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.MsBuild.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.MsBuild.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.MsBuild.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Core.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Ide.targets" Condition="Exists('..\packages\JetBrains.Platform.Core.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Core.Ide.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets" Condition="Exists('..\packages\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Sdk.111.0.20171218.132839\build\net45\JetBrains.Platform.Sdk.targets" Condition="Exists('..\packages\JetBrains.Platform.Sdk.111.0.20171218.132839\build\net45\JetBrains.Platform.Sdk.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.Tests.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Tests.Framework.targets" Condition="Exists('..\packages\JetBrains.Platform.Tests.Framework.111.0.20171218.132839\build\net45\JetBrains.Platform.Tests.Framework.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Shell.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Shell.targets" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Shell.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Shell.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Text.targets" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Text.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Text.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.UIInteractive.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Ide.targets" Condition="Exists('..\packages\JetBrains.Platform.UIInteractive.Ide.111.0.20171218.132839\build\net45\JetBrains.Platform.UIInteractive.Ide.targets')" />
+  <Import Project="..\packages\JetBrains.Platform.VisualStudio.111.0.20171218.132839\build\net45\JetBrains.Platform.VisualStudio.targets" Condition="Exists('..\packages\JetBrains.Platform.VisualStudio.111.0.20171218.132839\build\net45\JetBrains.Platform.VisualStudio.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Tasks.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Tasks.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Tasks.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Tasks.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Core.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Core.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.src.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.src.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.src.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.src.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.SolutionBuilder.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.SolutionBuilder.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.SolutionBuilder.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.SolutionBuilder.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UIInteractive.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Core.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Core.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Core.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.Diagramming.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Diagramming.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.Diagramming.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.Diagramming.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.SolutionAnalysis.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UnitTesting.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UnitTesting.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UnitTesting.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UnitTesting.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.test.Framework.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.test.Framework.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.test.Framework.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.test.Framework.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.UIInteractive.Features.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Features.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.UIInteractive.Features.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.UIInteractive.Features.targets')" />
+  <Import Project="..\packages\JetBrains.Psi.Features.VisualStudio.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.VisualStudio.targets" Condition="Exists('..\packages\JetBrains.Psi.Features.VisualStudio.111.0.20171218.133621\build\net45\JetBrains.Psi.Features.VisualStudio.targets')" />
+  <Import Project="..\packages\JetBrains.ReSharper.SDK.Internal.111.0.20171219.91646\build\net45\JetBrains.ReSharper.SDK.Internal.targets" Condition="Exists('..\packages\JetBrains.ReSharper.SDK.Internal.111.0.20171219.91646\build\net45\JetBrains.ReSharper.SDK.Internal.targets')" />
 </Project>

--- a/CleanCode/src/CleanCode/Settings/CleanCodeOptionsPage.cs
+++ b/CleanCode/src/CleanCode/Settings/CleanCodeOptionsPage.cs
@@ -1,9 +1,9 @@
 ﻿using System.Drawing;
 using CleanCode.Resources.Icons;
+using JetBrains.Application.UI.Options;
+using JetBrains.Application.UI.Options.OptionsDialog;
 using JetBrains.DataFlow;
 using JetBrains.ReSharper.Feature.Services.Daemon.OptionPages;
-using JetBrains.UI.Options;
-using JetBrains.UI.Options.OptionsDialog2.SimpleOptions;
 using JetBrains.UI.RichText;
 
 namespace CleanCode.Settings

--- a/CleanCode/src/CleanCode/packages.config
+++ b/CleanCode/src/CleanCode/packages.config
@@ -2,58 +2,66 @@
 <packages>
   <package id="Antlr2.Runtime" version="2.7.7.02" targetFramework="net45" />
   <package id="Antlr2.Tools" version="2.7.6.4" targetFramework="net45" />
-  <package id="Appccelerate.StateMachine.JetBrains" version="2.2.0.1" targetFramework="net45" />
-  <package id="DotNetZip.Reduced" version="1.9.1.8" targetFramework="net45" />
-  <package id="JetBrains.Annotations" version="10.4.0" targetFramework="net45" />
+  <package id="Appccelerate.StateMachine" version="3.3.0" targetFramework="net45" />
+  <package id="DotNetZip" version="1.10.1" targetFramework="net45" />
+  <package id="JetBrains.Annotations" version="11.0.0" targetFramework="net45" />
+  <package id="JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask" version="2.0.20170530.0" targetFramework="net45" developmentDependency="true" />
   <package id="JetBrains.Build.Platform.Tasks.ThemedIconsPacker" version="2.0.20151217.1" targetFramework="net45" developmentDependency="true" />
-  <package id="JetBrains.ExternalAnnotations" version="10.2.18" targetFramework="net45" />
-  <package id="JetBrains.MahApps.Metro" version="1.3.1" targetFramework="net45" />
+  <package id="JetBrains.ExternalAnnotations" version="10.2.34" targetFramework="net45" />
+  <package id="JetBrains.MahApps.Metro" version="1.5.0.1" targetFramework="net45" />
+  <package id="JetBrains.Microsoft.Deployment.Compression.Cab" version="3.11.0" targetFramework="net45" />
   <package id="JetBrains.NuGet.Core" version="2.14.1" targetFramework="net45" />
-  <package id="JetBrains.NuGet.Frameworks" version="4.0.0" targetFramework="net45" />
-  <package id="JetBrains.NuGet.Ultimate" version="4.0.0" targetFramework="net45" />
-  <package id="JetBrains.NuGet.Versioning" version="4.0.0" targetFramework="net45" />
-  <package id="JetBrains.Platform.Core.Ide" version="108.0.20170402.75356" targetFramework="net45" />
-  <package id="JetBrains.Platform.Core.Shell" version="108.0.20170402.74924" targetFramework="net45" />
-  <package id="JetBrains.Platform.Core.Text" version="108.0.20170402.75356" targetFramework="net45" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Framework" version="108.0.20170402.75356" targetFramework="net45" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop" version="108.0.20170402.75356" targetFramework="net45" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide" version="108.0.20170402.75356" targetFramework="net45" />
-  <package id="JetBrains.Platform.Lib.DevExpress" version="2.0.20150224.0" targetFramework="net45" />
-  <package id="JetBrains.Platform.Lib.Microsoft.Deployment.Compression.Cab" version="2.0.20140304.0" targetFramework="net45" />
-  <package id="JetBrains.Platform.Lib.System.Windows.Interactivity" version="3.0.40218" targetFramework="net45" />
-  <package id="JetBrains.Platform.Lib.WpfContrib" version="2.0.20150225.0" targetFramework="net45" />
-  <package id="JetBrains.Platform.MSBuild.Logger" version="1.0.20170130.0" targetFramework="net45" developmentDependency="true" />
-  <package id="JetBrains.Platform.RdProtocol" version="108.0.20170402.75356" targetFramework="net45" />
-  <package id="JetBrains.Platform.Symbols" version="108.0.20170402.75356" targetFramework="net45" />
-  <package id="JetBrains.Platform.Tests.Framework" version="108.0.20170402.75356" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.Core" version="108.0.20170403.124150" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.src" version="108.0.20170403.124150" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.Tasks" version="108.0.20170403.124150" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.test.Framework" version="108.0.20170403.124150" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.UnitTesting" version="108.0.20170403.124150" targetFramework="net45" />
-  <package id="JetBrains.ReSharper.SDK" version="2017.1.20170403.131543" targetFramework="net45" developmentDependency="true" />
-  <package id="JetBrains.ReSharper.SDK.Internal" version="108.0.20170403.131543" targetFramework="net45" />
-  <package id="JetBrains.System.Reflection.Metadata" version="1.0.0" targetFramework="net45" />
+  <package id="JetBrains.NuGet.Frameworks" version="4.3.0.10000" targetFramework="net45" />
+  <package id="JetBrains.NuGet.Ultimate" version="4.3.0.10000" targetFramework="net45" />
+  <package id="JetBrains.NuGet.Versioning" version="4.3.0.10000" targetFramework="net45" />
+  <package id="JetBrains.NUnit.ReSharperRunner2" version="2.6.408" targetFramework="net45" />
+  <package id="JetBrains.NUnit.ReSharperRunner3" version="3.0.12.1" targetFramework="net45" />
+  <package id="JetBrains.Platform.Core.Ide" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.Core.Shell" version="109.0.20170824.130529" targetFramework="net45" />
+  <package id="JetBrains.Platform.Core.Text" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.Interop.CommandLine" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Framework" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.Lib.DevExpress" version="2.0.20170610" targetFramework="net45" />
+  <package id="JetBrains.Platform.Lib.WpfContrib" version="2.0.20170610" targetFramework="net45" />
+  <package id="JetBrains.Platform.MSBuild.Logger" version="1.0.20170331.0" targetFramework="net45" developmentDependency="true" />
+  <package id="JetBrains.Platform.RdProtocol" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.Sdk" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.Tests.Framework" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.UIInteractive.Ide" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.UIInteractive.Shell" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Platform.UIInteractive.Text" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.Core" version="109.0.20170824.132357" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.src" version="109.0.20170824.132357" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.Tasks" version="109.0.20170824.132357" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.test.Framework" version="109.0.20170824.132357" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.UIInteractive.Core" version="109.0.20170824.132357" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.UnitTesting" version="109.0.20170824.132357" targetFramework="net45" />
+  <package id="JetBrains.ReSharper.SDK" version="2017.2.0" targetFramework="net45" developmentDependency="true" />
+  <package id="JetBrains.ReSharper.SDK.Internal" version="109.0.20170824.140122" targetFramework="net45" />
+  <package id="JetBrains.SharpZipLib.Stripped" version="0.87.20170720.14" targetFramework="net45" />
+  <package id="JetBrains.Should" version="1.1.20" targetFramework="net45" />
+  <package id="JetBrains.System.Reflection.Metadata" version="20170417.0.0.0" targetFramework="net45" />
+  <package id="JetBrains.System.Windows.Interactivity" version="3.0.40218.0" targetFramework="net45" />
+  <package id="JetBrains.Toolset.ScriptSourcesCompiler.Interface" version="1.0.20170420.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.FileSystems" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.StaticFiles" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="NUnit.ReSharperRunner2" version="2.6.408" targetFramework="net45" />
-  <package id="NUnit.ReSharperRunner3" version="3.0.12" targetFramework="net45" />
   <package id="NVelocity" version="1.0.3" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="sharpcompress" version="0.11.6" targetFramework="net45" />
-  <package id="SharpZipLib.JetBrains.Stripped" version="0.87.20161027.6" targetFramework="net45" />
   <package id="Sprache.JetBrains" version="2.1.0" targetFramework="net45" />
   <package id="Vestris.ResourceLib.JetBrains" version="1.4.20150303.0" targetFramework="net45" />
-  <package id="Wave" version="8.0.0.0" targetFramework="net45" />
+  <package id="Wave" version="9.0.0.0" targetFramework="net45" />
   <package id="Windows7APICodePack.JetBrains.Stripped" version="1.1.20150225.0" targetFramework="net45" />
   <package id="xmlrpcnet" version="2.5.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net45" />
   <package id="xunit.JetBrains" version="1.9.2" targetFramework="net45" />
   <package id="xunit.runner.utility" version="2.2.0" targetFramework="net45" />
+  <package id="YamlDotNet.Signed" version="4.2.1" targetFramework="net45" />
 </packages>

--- a/CleanCode/src/CleanCode/packages.config
+++ b/CleanCode/src/CleanCode/packages.config
@@ -4,41 +4,50 @@
   <package id="Antlr2.Tools" version="2.7.6.4" targetFramework="net45" />
   <package id="Appccelerate.StateMachine" version="3.3.0" targetFramework="net45" />
   <package id="DotNetZip" version="1.10.1" targetFramework="net45" />
-  <package id="JetBrains.Annotations" version="11.0.0" targetFramework="net45" />
-  <package id="JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask" version="2.0.20170530.0" targetFramework="net45" developmentDependency="true" />
+  <package id="JetBrains.Annotations" version="11.1.0" targetFramework="net45" />
+  <package id="JetBrains.Build.Platform.Tasks.ProxyToSolutionCompiledTask" version="2.0.20170904.2" targetFramework="net45" developmentDependency="true" />
   <package id="JetBrains.Build.Platform.Tasks.ThemedIconsPacker" version="2.0.20151217.1" targetFramework="net45" developmentDependency="true" />
-  <package id="JetBrains.ExternalAnnotations" version="10.2.34" targetFramework="net45" />
+  <package id="JetBrains.ExternalAnnotations" version="10.2.37" targetFramework="net45" />
   <package id="JetBrains.MahApps.Metro" version="1.5.0.1" targetFramework="net45" />
   <package id="JetBrains.Microsoft.Deployment.Compression.Cab" version="3.11.0" targetFramework="net45" />
   <package id="JetBrains.NuGet.Core" version="2.14.1" targetFramework="net45" />
-  <package id="JetBrains.NuGet.Frameworks" version="4.3.0.10000" targetFramework="net45" />
-  <package id="JetBrains.NuGet.Ultimate" version="4.3.0.10000" targetFramework="net45" />
-  <package id="JetBrains.NuGet.Versioning" version="4.3.0.10000" targetFramework="net45" />
+  <package id="JetBrains.NuGet.Frameworks" version="4.5.0.0" targetFramework="net45" />
+  <package id="JetBrains.NuGet.Ultimate" version="4.5.0.0" targetFramework="net45" />
+  <package id="JetBrains.NuGet.Versioning" version="4.5.0.0" targetFramework="net45" />
   <package id="JetBrains.NUnit.ReSharperRunner2" version="2.6.408" targetFramework="net45" />
-  <package id="JetBrains.NUnit.ReSharperRunner3" version="3.0.12.1" targetFramework="net45" />
-  <package id="JetBrains.Platform.Core.Ide" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Platform.Core.Shell" version="109.0.20170824.130529" targetFramework="net45" />
-  <package id="JetBrains.Platform.Core.Text" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Platform.Interop.CommandLine" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Framework" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide" version="109.0.20170824.131327" targetFramework="net45" />
+  <package id="JetBrains.NUnit.ReSharperRunner3" version="3.6.3" targetFramework="net45" />
+  <package id="JetBrains.Platform.Core.Ide" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.Core.MsBuild" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.Core.Shell" version="111.0.20171218.132440" targetFramework="net45" />
+  <package id="JetBrains.Platform.Core.Text" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.Interop.CommandLine" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Framework" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop.Console" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.Interop.dotMemoryUnit.Interop.Ide" version="111.0.20171218.132839" targetFramework="net45" />
   <package id="JetBrains.Platform.Lib.DevExpress" version="2.0.20170610" targetFramework="net45" />
+  <package id="JetBrains.Platform.Lib.VisualStudio.AnyVs.ShellInterop.PrivateBuild" version="2.0.20141005.1" targetFramework="net45" />
   <package id="JetBrains.Platform.Lib.WpfContrib" version="2.0.20170610" targetFramework="net45" />
-  <package id="JetBrains.Platform.MSBuild.Logger" version="1.0.20170331.0" targetFramework="net45" developmentDependency="true" />
-  <package id="JetBrains.Platform.RdProtocol" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Platform.Sdk" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Platform.Tests.Framework" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Platform.UIInteractive.Ide" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Platform.UIInteractive.Shell" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Platform.UIInteractive.Text" version="109.0.20170824.131327" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.Core" version="109.0.20170824.132357" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.src" version="109.0.20170824.132357" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.Tasks" version="109.0.20170824.132357" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.test.Framework" version="109.0.20170824.132357" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.UIInteractive.Core" version="109.0.20170824.132357" targetFramework="net45" />
-  <package id="JetBrains.Psi.Features.UnitTesting" version="109.0.20170824.132357" targetFramework="net45" />
-  <package id="JetBrains.ReSharper.SDK" version="2017.2.0" targetFramework="net45" developmentDependency="true" />
-  <package id="JetBrains.ReSharper.SDK.Internal" version="109.0.20170824.140122" targetFramework="net45" />
+  <package id="JetBrains.Platform.MSBuild.Logger.Api" version="1.0.20170809" targetFramework="net45" />
+  <package id="JetBrains.Platform.RdProtocol" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.Sdk" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.Tests.Framework" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.UIInteractive.Ide" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.UIInteractive.Shell" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.UIInteractive.Text" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Platform.VisualStudio" version="111.0.20171218.132839" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.Core" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.Diagramming" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.SolutionBuilder" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.src" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.Tasks" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.test.Framework" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.UIInteractive.Core" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.UIInteractive.Features" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.UIInteractive.SolutionAnalysis" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.UnitTesting" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.Psi.Features.VisualStudio" version="111.0.20171218.133621" targetFramework="net45" />
+  <package id="JetBrains.ReSharper.SDK" version="2017.3.0" targetFramework="net45" developmentDependency="true" />
+  <package id="JetBrains.ReSharper.SDK.Internal" version="111.0.20171219.91646" targetFramework="net45" />
   <package id="JetBrains.SharpZipLib.Stripped" version="0.87.20170720.14" targetFramework="net45" />
   <package id="JetBrains.Should" version="1.1.20" targetFramework="net45" />
   <package id="JetBrains.System.Reflection.Metadata" version="20170417.0.0.0" targetFramework="net45" />
@@ -57,7 +66,7 @@
   <package id="sharpcompress" version="0.11.6" targetFramework="net45" />
   <package id="Sprache.JetBrains" version="2.1.0" targetFramework="net45" />
   <package id="Vestris.ResourceLib.JetBrains" version="1.4.20150303.0" targetFramework="net45" />
-  <package id="Wave" version="9.0.0.0" targetFramework="net45" />
+  <package id="Wave" version="11.0.0.0" targetFramework="net45" />
   <package id="Windows7APICodePack.JetBrains.Stripped" version="1.1.20150225.0" targetFramework="net45" />
   <package id="xmlrpcnet" version="2.5.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net45" />

--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ Install from ReSharper &rarr; Extension Manager.
 
 ## License
 
-Licensed under MIT (c) 2012 - 2016  Hadi Hariri and Contributors
+Licensed under MIT (c) 2012 - 2017  Hadi Hariri and Contributors
 
 Note: All references to [Clean Code](http://www.cleancoders.com/), including but not limited to the Clean Code icon are used with permission of Robert C. Martin (a.k.a. UncleBob)


### PR DESCRIPTION
Updated to wave 11 for ReSharper 2017.3 support.
Incremented version number to 5.3.0
Based this update on top of the still-unmerged ReSharper 2017.2 update #34 
